### PR TITLE
Feature/healthcheck for worker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v1.10.41"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "61153c768f31ee5f130071d08fc82b85208528de"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/fukata/golang-stats-api-handler"
   packages = ["."]
   revision = "90f0b59102629831cc109845475a8d77043412ec"
@@ -43,9 +49,15 @@
   revision = "5ccdfb18c776b740aecaf085c4d9a2779199c279"
   version = "v1.0.0"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/net"
+  packages = ["context"]
+  revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a86c5793088097a18e7219ce8da5c981c28a5c9e8a51fc8774db037474340751"
+  inputs-digest = "bf5f358069c8e56687d93560b39a8b72408bfa448264dc4f5eec5dc1edd9ffaa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/sqsd/main.go
+++ b/cmd/sqsd/main.go
@@ -111,16 +111,18 @@ func main() {
 
 	logger := sqsd.NewLogger(config.Worker.LogLevel)
 
+	tracker := sqsd.NewQueueTracker(config.Worker.MaxProcessCount)
+	if !tracker.HealthCheck(config.HealthCheck) {
+		logger.Error("healthcheck failed.")
+		return
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	wg := &sync.WaitGroup{}
 
-	wg.Add(1)
+	wg.Add(2)
 	go waitSignal(cancel, wg)
-
-	tracker := sqsd.NewQueueTracker(config.Worker.MaxProcessCount)
-
-	wg.Add(1)
 	go RunStatServer(tracker, config.Stat.ServerPort, ctx, wg)
 
 	awsConf := &aws.Config{

--- a/cmd/sqsd/main.go
+++ b/cmd/sqsd/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	logger := sqsd.NewLogger(config.Worker.LogLevel)
 
-	tracker := sqsd.NewQueueTracker(config.Worker.MaxProcessCount)
+	tracker := sqsd.NewQueueTracker(config.Worker.MaxProcessCount, logger)
 	if !tracker.HealthCheck(config.HealthCheck) {
 		logger.Error("healthcheck failed.")
 		return
@@ -133,8 +133,8 @@ func main() {
 	}))
 	resource := sqsd.NewResource(sqs.New(sess, awsConf), config.SQS.QueueURL())
 
-	msgConsumer := sqsd.NewMessageConsumer(resource, tracker, logger, config.Worker.WorkerURL)
-	msgProducer := sqsd.NewMessageProducer(resource, tracker, logger)
+	msgConsumer := sqsd.NewMessageConsumer(resource, tracker, config.Worker.WorkerURL)
+	msgProducer := sqsd.NewMessageProducer(resource, tracker)
 	wg.Add(2)
 	go msgConsumer.Run(ctx, wg)
 	go msgProducer.Run(ctx, wg)

--- a/conf.go
+++ b/conf.go
@@ -23,8 +23,9 @@ type WorkerConf struct {
 }
 
 type HealthCheckConf struct {
-	URL            string `toml:"url"`
-	MaxElapsedTime uint   `toml:"max_elapsed_time"`
+	URL           string `toml:"url"`
+	MaxElapsedSec int64  `toml:"max_elapsed_sec"`
+	MaxRequestMS  int64  `toml:"max_request_ms"`
 }
 
 func (c WorkerConf) Validate() error {
@@ -92,8 +93,8 @@ func (c HealthCheckConf) Validate() error {
 		if err != nil || !strings.HasPrefix(uri.Scheme, "http") {
 			return errors.New("healthcheck.url is not HTTP URL: " + c.URL)
 		}
-		if c.MaxElapsedTime == 0 {
-			return errors.New("healthcheck.max_elapsed_time is required")
+		if c.MaxElapsedSec == 0 {
+			return errors.New("healthcheck.max_elapsed_sec is required")
 		}
 	}
 	return nil
@@ -113,6 +114,10 @@ func (c *Conf) Init() {
 	}
 	if c.Worker.LogLevel == "" {
 		c.Worker.LogLevel = "INFO"
+	}
+
+	if c.HealthCheck.URL != "" && c.HealthCheck.MaxRequestMS == 0 {
+		c.HealthCheck.MaxRequestMS = 1000
 	}
 }
 

--- a/conf.go
+++ b/conf.go
@@ -45,10 +45,6 @@ func (c WorkerConf) Validate() error {
 	return nil
 }
 
-func (c WorkerConf) CanSupportHealthCheck() bool {
-	return c.HealthCheckURL != ""
-}
-
 type StatConf struct {
 	ServerPort int `toml:"server_port"`
 }

--- a/conf.go
+++ b/conf.go
@@ -19,6 +19,7 @@ type WorkerConf struct {
 	MaxProcessCount uint   `toml:"max_process_count"`
 	WorkerURL       string `toml:"worker_url"`
 	LogLevel        string `toml:"log_level"`
+	HealthCheckURL  string `toml:"healthcheck_url"`
 }
 
 func (c WorkerConf) Validate() error {
@@ -35,7 +36,17 @@ func (c WorkerConf) Validate() error {
 	if _, ok := levelMap[c.LogLevel]; !ok {
 		return errors.New("worker.log_level is invalid: " + c.LogLevel)
 	}
+	if c.HealthCheckURL != "" {
+		uri, err := url.ParseRequestURI(c.HealthCheckURL)
+		if err != nil || !strings.HasPrefix(uri.Scheme, "http") {
+			return errors.New("worker.healthcheck_url is not HTTP URL: " + c.HealthCheckURL)
+		}
+	}
 	return nil
+}
+
+func (c WorkerConf) CanSupportHealthCheck() bool {
+	return c.HealthCheckURL != ""
 }
 
 type StatConf struct {

--- a/conf_test.go
+++ b/conf_test.go
@@ -84,6 +84,11 @@ func TestValidateConf(t *testing.T) {
 		t.Error("Worker.LogLevel should be invalid")
 	}
 	c.Worker.LogLevel = "INFO"
+
+	if c.HealthCheck.ShouldSupport() {
+		t.Error("healthcheck should not support for empty url")
+	}
+
 	c.HealthCheck.URL = "hoge://fuga/piyo"
 	if err := c.Validate(); err == nil {
 		t.Error("HealthCheck.URL should be invalid")
@@ -93,6 +98,10 @@ func TestValidateConf(t *testing.T) {
 		t.Error("HealthCheck.MaxElapsedTime is required")
 	}
 	c.HealthCheck.MaxElapsedTime = 1
+
+	if !c.HealthCheck.ShouldSupport() {
+		t.Error("healthcheck should support for filled url")
+	}
 
 	if err := c.Validate(); err != nil {
 		t.Error("WorkerConf should be valid: ", err)

--- a/conf_test.go
+++ b/conf_test.go
@@ -92,14 +92,6 @@ func TestValidateConf(t *testing.T) {
 	if err := c.Validate(); err != nil {
 		t.Error("WorkerConf should be valid: ", err)
 	}
-	if !c.Worker.CanSupportHealthCheck() {
-		t.Error("healthcheck support should be true")
-	}
-	c.Worker.HealthCheckURL = ""
-	if c.Worker.CanSupportHealthCheck() {
-		t.Error("healthcheck support should not be true")
-	}
-
 }
 
 func TestNewConf(t *testing.T) {

--- a/conf_test.go
+++ b/conf_test.go
@@ -84,11 +84,16 @@ func TestValidateConf(t *testing.T) {
 		t.Error("Worker.LogLevel should be invalid")
 	}
 	c.Worker.LogLevel = "INFO"
-	c.Worker.HealthCheckURL = "hoge://fuga/piyo"
+	c.HealthCheck.URL = "hoge://fuga/piyo"
 	if err := c.Validate(); err == nil {
-		t.Error("Worker.HealthCheckURL should be invalid")
+		t.Error("HealthCheck.URL should be invalid")
 	}
-	c.Worker.HealthCheckURL = "http://localhost/hoge/fuga"
+	c.HealthCheck.URL = "http://localhost/hoge/fuga"
+	if err := c.Validate(); err == nil {
+		t.Error("HealthCheck.MaxElapsedTime is required")
+	}
+	c.HealthCheck.MaxElapsedTime = 1
+
 	if err := c.Validate(); err != nil {
 		t.Error("WorkerConf should be valid: ", err)
 	}

--- a/conf_test.go
+++ b/conf_test.go
@@ -68,6 +68,7 @@ func TestValidateConf(t *testing.T) {
 	if err := c.Validate(); err == nil {
 		t.Error("SQS.URL should be url")
 	}
+	c.SQS.URL = ""
 
 	c.Worker.WorkerURL = ""
 	if err := c.Validate(); err == nil {
@@ -80,8 +81,25 @@ func TestValidateConf(t *testing.T) {
 	c.Worker.WorkerURL = "http://localhost/foo/bar"
 	c.Worker.LogLevel = "WRONG"
 	if err := c.Validate(); err == nil {
-		t.Error("Worker.LogLevel should be invalid: ", err)
+		t.Error("Worker.LogLevel should be invalid")
 	}
+	c.Worker.LogLevel = "INFO"
+	c.Worker.HealthCheckURL = "hoge://fuga/piyo"
+	if err := c.Validate(); err == nil {
+		t.Error("Worker.HealthCheckURL should be invalid")
+	}
+	c.Worker.HealthCheckURL = "http://localhost/hoge/fuga"
+	if err := c.Validate(); err != nil {
+		t.Error("WorkerConf should be valid: ", err)
+	}
+	if !c.Worker.CanSupportHealthCheck() {
+		t.Error("healthcheck support should be true")
+	}
+	c.Worker.HealthCheckURL = ""
+	if c.Worker.CanSupportHealthCheck() {
+		t.Error("healthcheck support should not be true")
+	}
+
 }
 
 func TestNewConf(t *testing.T) {

--- a/conf_test.go
+++ b/conf_test.go
@@ -95,9 +95,9 @@ func TestValidateConf(t *testing.T) {
 	}
 	c.HealthCheck.URL = "http://localhost/hoge/fuga"
 	if err := c.Validate(); err == nil {
-		t.Error("HealthCheck.MaxElapsedTime is required")
+		t.Error("HealthCheck.MaxElapsedSec is required")
 	}
-	c.HealthCheck.MaxElapsedTime = 1
+	c.HealthCheck.MaxElapsedSec = 1
 
 	if !c.HealthCheck.ShouldSupport() {
 		t.Error("healthcheck should support for filled url")

--- a/message_consumer.go
+++ b/message_consumer.go
@@ -17,14 +17,14 @@ type MessageConsumer struct {
 	Logger           Logger
 }
 
-func NewMessageConsumer(resource *Resource, tracker *QueueTracker, logger Logger, url string) *MessageConsumer {
+func NewMessageConsumer(resource *Resource, tracker *QueueTracker, url string) *MessageConsumer {
 	return &MessageConsumer{
 		Tracker:          tracker,
 		Resource:         resource,
 		URL:              url,
 		OnHandleJobStart: func(q *Queue) {},
 		OnHandleJobEnds:  func(jobID string, ok bool, err error) {},
-		Logger:           logger,
+		Logger:           tracker.Logger,
 	}
 }
 

--- a/message_consumer_test.go
+++ b/message_consumer_test.go
@@ -33,7 +33,7 @@ func TestHandleJob(t *testing.T) {
 
 	ctx := context.Background()
 
-	ts := MockJobServer()
+	ts := MockServer()
 	defer ts.Close()
 
 	wg := &sync.WaitGroup{}

--- a/message_consumer_test.go
+++ b/message_consumer_test.go
@@ -18,9 +18,8 @@ type HandleJobResponse struct {
 func TestHandleJob(t *testing.T) {
 	mc := NewMockClient()
 	r := NewResource(mc, "http://example.com/foo/bar/queue")
-	l := NewLogger("DEBUG")
-	tr := NewQueueTracker(5)
-	msgc := NewMessageConsumer(r, tr, l, "")
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
+	msgc := NewMessageConsumer(r, tr, "")
 
 	receivedChan := make(chan *HandleJobResponse)
 	msgc.OnHandleJobEnds = func(jobID string, ok bool, err error) {

--- a/message_producer.go
+++ b/message_producer.go
@@ -14,14 +14,14 @@ type MessageProducer struct {
 	Logger          Logger
 }
 
-func NewMessageProducer(resource *Resource, tracker *QueueTracker, logger Logger) *MessageProducer {
+func NewMessageProducer(resource *Resource, tracker *QueueTracker) *MessageProducer {
 	return &MessageProducer{
 		Resource: resource,
 		Tracker:  tracker,
 		HandleEmptyFunc: func() {
 			time.Sleep(1 * time.Second)
 		},
-		Logger: logger,
+		Logger: tracker.Logger,
 	}
 }
 

--- a/message_producer_test.go
+++ b/message_producer_test.go
@@ -15,9 +15,8 @@ func TestNewReceiverAndDoHandle(t *testing.T) {
 	mc := NewMockClient()
 	rs := NewResource(mc, "http://example.com/foo/bar/queue")
 	rs.ReceiveParams.WaitTimeSeconds = aws.Int64(1)
-	tr := NewQueueTracker(5)
-	l := NewLogger("DEBUG")
-	pr := NewMessageProducer(rs, tr, l)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
+	pr := NewMessageProducer(rs, tr)
 	if pr == nil {
 		t.Error("receiver not loaded")
 	}
@@ -136,9 +135,8 @@ func TestReceiverRun(t *testing.T) {
 	mc := NewMockClient()
 	rs := NewResource(mc, "http://example.com/foo/bar/queue")
 	rs.ReceiveParams.WaitTimeSeconds = aws.Int64(1)
-	tr := NewQueueTracker(5)
-	l := NewLogger("DEBUG")
-	pr := NewMessageProducer(rs, tr, l)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
+	pr := NewMessageProducer(rs, tr)
 
 	wg := &sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/mock.go
+++ b/mock.go
@@ -60,7 +60,7 @@ func (c *MockClient) DeleteMessage(*sqs.DeleteMessageInput) (*sqs.DeleteMessageO
 	return &sqs.DeleteMessageOutput{}, nil
 }
 
-func MockJobServer() *httptest.Server {
+func MockServer() *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-Type", "text")

--- a/queue_tracker.go
+++ b/queue_tracker.go
@@ -86,7 +86,7 @@ func (t *QueueTracker) HealthCheck(c HealthCheckConf) bool {
 		defer cancel()
 		resp, err := client.Do(req.WithContext(ctx))
 		if err != nil {
-			t.Logger.Warn(fmt.Sprintf("healthcheck request failed. %s\n", err))
+			t.Logger.Warn(fmt.Sprintf("healthcheck request failed. %s", err))
 			return err
 		}
 		defer resp.Body.Close()

--- a/queue_tracker.go
+++ b/queue_tracker.go
@@ -91,7 +91,7 @@ func (t *QueueTracker) HealthCheck(c HealthCheckConf) bool {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			t.Logger.Warn("healthcheck response code != 200")
+			t.Logger.Warn(fmt.Sprintf("healthcheck response code != 200: %s", resp.Status))
 			return errors.New("response status code != 200")
 		}
 		t.Logger.Info("healthcheck request success.")

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestQueueTracker(t *testing.T) {
-	tracker := NewQueueTracker(1)
+	tracker := NewQueueTracker(1, NewLogger("DEBUG"))
 	if tracker == nil {
 		t.Error("job tracker not loaded.")
 	}
@@ -86,7 +86,7 @@ func TestQueueTracker(t *testing.T) {
 }
 
 func TestJobWorking(t *testing.T) {
-	tr := NewQueueTracker(5)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
 
 	if !tr.JobWorking {
 		t.Error("JobWorking false")
@@ -104,7 +104,7 @@ func TestJobWorking(t *testing.T) {
 }
 
 func TestCurrentSummaries(t *testing.T) {
-	tr := NewQueueTracker(5)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
 	now := time.Now()
 	for i := 1; i <= 2; i++ {
 		iStr := strconv.Itoa(i)
@@ -131,7 +131,7 @@ func TestCurrentSummaries(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	tr := NewQueueTracker(5)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
 	hc := HealthCheckConf{}
 
 	if !tr.HealthCheck(hc) {

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -144,6 +144,7 @@ func TestHealthCheck(t *testing.T) {
 	t.Run("error returns", func(t *testing.T) {
 		hc.URL = ts.URL + "/error"
 		hc.MaxElapsedSec = 1
+		hc.MaxRequestMS = 1000
 		if tr.HealthCheck(hc) {
 			t.Error("healthcheck is success. but expected failure.")
 		}

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -129,3 +129,42 @@ func TestCurrentSummaries(t *testing.T) {
 		}
 	}
 }
+
+func TestHealthCheck(t *testing.T) {
+	tr := NewQueueTracker(5)
+	hc := HealthCheckConf{}
+
+	if !tr.HealthCheck(hc) {
+		t.Error("healthcheck should not support.")
+	}
+
+	ts := MockServer()
+	defer ts.Close()
+
+	t.Run("error returns", func(t *testing.T) {
+		hc.URL = ts.URL + "/error"
+		hc.MaxElapsedSec = 1
+		if tr.HealthCheck(hc) {
+			t.Error("healthcheck is success. but expected failure.")
+		}
+	})
+
+	t.Run("request timeout", func(t *testing.T) {
+		hc.URL = ts.URL + "/long"
+		hc.MaxElapsedSec = 2
+		hc.MaxRequestMS = 300
+		if tr.HealthCheck(hc) {
+			t.Error("healthcheck is success. but expected failure.")
+		}
+	})
+
+	t.Run("response ok", func(t *testing.T) {
+		hc.URL = ts.URL + "/ok"
+		hc.MaxElapsedSec = 3
+		hc.MaxRequestMS = 1000
+		if !tr.HealthCheck(hc) {
+			t.Error("healthcheck is failure. but expected success.")
+		}
+	})
+
+}

--- a/stat_handler_test.go
+++ b/stat_handler_test.go
@@ -62,7 +62,7 @@ func TestRenderJSON(t *testing.T) {
 }
 
 func TestWorkerCurrentSummaryAndJobsHandler(t *testing.T) {
-	tr := NewQueueTracker(5)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
 	h := &StatHandler{tr}
 
 	for i := 1; i <= 5; i++ {
@@ -150,7 +150,7 @@ func TestWorkerCurrentSummaryAndJobsHandler(t *testing.T) {
 }
 
 func TestWorkerPauseAndResumeHandler(t *testing.T) {
-	tr := NewQueueTracker(5)
+	tr := NewQueueTracker(5, NewLogger("DEBUG"))
 	h := &StatHandler{tr}
 
 	pauseController := h.WorkerPauseHandler()

--- a/test/conf/config_valid.toml
+++ b/test/conf/config_valid.toml
@@ -1,3 +1,7 @@
+[healthcheck]
+url = "http://127.0.0.1:8080/healthcheck"
+max_elapsed_time  = 10
+
 [worker]
 interval_seconds=1
 max_process_count=40

--- a/test/conf/config_valid.toml
+++ b/test/conf/config_valid.toml
@@ -1,6 +1,6 @@
 [healthcheck]
 url = "http://127.0.0.1:8080/healthcheck"
-max_elapsed_time  = 10
+max_elapsed_sec  = 10
 
 [worker]
 interval_seconds=1


### PR DESCRIPTION
起動時にworkerのhealthcheckに対して確認を行えるようにする。
sqsd側が先に起動したとしても、workerの起動が確認できるまでqueueの取得を待てるようにするため。