### PR TITLE
tomlのバージョンアップによりDecodeが使えるようになっていた

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,9 +3,37 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/sqs","service/sqs/sqsiface","service/sts"]
-  revision = "af01be3e6edf79e6f07b5816cfe0d2c6717e5c7f"
-  version = "v1.10.41"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/sqs",
+    "service/sqs/sqsiface",
+    "service/sts"
+  ]
+  revision = "c8c4e0c0514d87f930c1342fef390db5329928b7"
+  version = "v1.13.20"
 
 [[projects]]
   name = "github.com/cenkalti/backoff"
@@ -22,8 +50,8 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
-  version = "v1.28.2"
+  revision = "6333e38ac20b8949a8dd68baa3650f4dee8f39f0"
+  version = "v1.33.0"
 
 [[projects]]
   branch = "master"
@@ -34,20 +62,13 @@
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
-  version = "0.2.2"
-
-[[projects]]
-  name = "github.com/pelletier/go-buffruneio"
-  packages = ["."]
-  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
-  version = "v0.2.0"
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "5ccdfb18c776b740aecaf085c4d9a2779199c279"
-  version = "v1.0.0"
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -58,6 +79,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bf5f358069c8e56687d93560b39a8b72408bfa448264dc4f5eec5dc1edd9ffaa"
+  inputs-digest = "59b3469c75f39458d664953738d72b461092ef536c45b43c6a65992337165f2c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/conf.go
+++ b/conf.go
@@ -1,8 +1,10 @@
 package sqsd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"strings"
 
@@ -218,13 +220,14 @@ func (c *Conf) Validate() error {
 
 // NewConf returns aggregated sqsd configuration object.
 func NewConf(filepath string) (*Conf, error) {
-	config, err := toml.LoadFile(filepath)
+	data, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}
-
 	sqsdConf := &Conf{}
-	config.Unmarshal(sqsdConf)
+	if err := toml.NewDecoder(bytes.NewBuffer(data)).Decode(sqsdConf); err != nil {
+		return nil, err
+	}
 	sqsdConf.Init()
 
 	if err := sqsdConf.Validate(); err != nil {


### PR DESCRIPTION
v1.1.0かららしい。
ということで、 `Decode` の方を使用する。