### PR TITLE
worker response status logging when status is not 200

### DIFF
--- a/message_consumer.go
+++ b/message_consumer.go
@@ -2,6 +2,7 @@ package sqsd
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -81,7 +82,7 @@ func (c *MessageConsumer) CallWorker(ctx context.Context, q Queue) (bool, error)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return false, nil
+		return false, errors.New("CallWorker failed. worker response status: " + resp.Status)
 	}
 
 	return true, nil

--- a/message_consumer_test.go
+++ b/message_consumer_test.go
@@ -11,7 +11,6 @@ import (
 
 type HandleJobResponse struct {
 	JobID string
-	Ok    bool
 	Err   error
 }
 
@@ -23,10 +22,9 @@ func TestHandleJob(t *testing.T) {
 	msgc := NewMessageConsumer(r, tr, "")
 
 	receivedChan := make(chan *HandleJobResponse)
-	msgc.OnHandleJobEnds = func(jobID string, ok bool, err error) {
+	msgc.OnHandleJobEnds = func(jobID string, err error) {
 		receivedChan <- &HandleJobResponse{
 			JobID: jobID,
-			Ok:    ok,
 			Err:   err,
 		}
 	}
@@ -59,12 +57,8 @@ func TestHandleJob(t *testing.T) {
 			t.Error("wrong job processed")
 		}
 
-		if receivedRes.Ok {
-			t.Error("error not returns")
-		}
-
-		if receivedRes.Err != nil {
-			t.Error("error found")
+		if receivedRes.Err == nil {
+			t.Error("error not found")
 		}
 	})
 
@@ -82,10 +76,6 @@ func TestHandleJob(t *testing.T) {
 
 		if receivedRes.JobID != queue.ID {
 			t.Error("wrong job processed")
-		}
-
-		if !receivedRes.Ok {
-			t.Error("error returns")
 		}
 
 		if receivedRes.Err != nil {
@@ -110,10 +100,6 @@ func TestHandleJob(t *testing.T) {
 
 		if receivedRes.JobID != queue.ID {
 			t.Error("wrong queue processed")
-		}
-
-		if receivedRes.Ok {
-			t.Error("error not returns")
 		}
 
 		if receivedRes.Err == nil {


### PR DESCRIPTION
I want to know worker response status when worker response is not `http.StatusOK`. 

I changed to `(*MessageConsumer) CallWorker` return error with worker response status code when response status code is not `http.StatusOK`.
It aim to logging response status in `(*MessageConsumer) HandleJob`.