### PR TITLE
Add /scoreboard endpoint to StatHandler

### DIFF
--- a/message_consumer.go
+++ b/message_consumer.go
@@ -61,7 +61,7 @@ func (c *MessageConsumer) HandleJob(ctx context.Context, q Queue) {
 	if ok {
 		c.Resource.DeleteMessage(q.Receipt)
 	}
-	c.Tracker.Complete(q)
+	c.Tracker.Complete(q, ok)
 	c.Logger.Debugf("job[%s] HandleJob finished.", q.ID)
 	c.OnHandleJobEnds(q.ID, ok, err)
 }

--- a/message_consumer.go
+++ b/message_consumer.go
@@ -57,11 +57,13 @@ func (c *MessageConsumer) HandleJob(ctx context.Context, q Queue) {
 	ok, err := c.CallWorker(ctx, q)
 	if err != nil {
 		c.Logger.Errorf("job[%s] HandleJob request error: %s", q.ID, err)
+		q = q.ResultFailed()
 	}
 	if ok {
 		c.Resource.DeleteMessage(q.Receipt)
+		q = q.ResultSucceeded()
 	}
-	c.Tracker.Complete(q, ok)
+	c.Tracker.Complete(q)
 	c.Logger.Debugf("job[%s] HandleJob finished.", q.ID)
 	c.OnHandleJobEnds(q.ID, ok, err)
 }

--- a/queue.go
+++ b/queue.go
@@ -6,12 +6,41 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
+type QueueResultStatus int
+
+const (
+	NotRequested   = iota // default
+	RequestSuccess = iota
+	RequestFail    = iota
+)
+
 // Queue provides transition from sqs.Message
 type Queue struct {
-	ID         string
-	Payload    string
-	Receipt    string
-	ReceivedAt time.Time
+	ID           string
+	Payload      string
+	Receipt      string
+	ReceivedAt   time.Time
+	ResultStatus QueueResultStatus
+}
+
+func (q Queue) ResultSucceeded() Queue {
+	return Queue{
+		ID:           q.ID,
+		Payload:      q.Payload,
+		Receipt:      q.Receipt,
+		ReceivedAt:   q.ReceivedAt,
+		ResultStatus: RequestSuccess,
+	}
+}
+
+func (q Queue) ResultFailed() Queue {
+	return Queue{
+		ID:           q.ID,
+		Payload:      q.Payload,
+		Receipt:      q.Receipt,
+		ReceivedAt:   q.ReceivedAt,
+		ResultStatus: RequestFail,
+	}
 }
 
 // QueueSummary provides transition from Queue for stat

--- a/queue_tracker.go
+++ b/queue_tracker.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -16,6 +17,21 @@ type QueueTracker struct {
 	Logger          Logger
 	queueChan       chan Queue
 	queueStack      chan struct{}
+	ScoreBoard      ScoreBoard
+}
+
+type ScoreBoard struct {
+	TotalSucceeded int64
+	TotalFailed    int64
+	MaxWorker      int
+}
+
+func (s *ScoreBoard) ReportScore(success bool) {
+	if success {
+		atomic.AddInt64(&s.TotalSucceeded, 1)
+	} else {
+		atomic.AddInt64(&s.TotalFailed, 1)
+	}
 }
 
 // NewQueueTracker returns QueueTracker object
@@ -27,6 +43,9 @@ func NewQueueTracker(maxProcCount uint, logger Logger) *QueueTracker {
 		Logger:          logger,
 		queueChan:       make(chan Queue, procCount),
 		queueStack:      make(chan struct{}, procCount),
+		ScoreBoard: ScoreBoard{
+			MaxWorker: procCount,
+		},
 	}
 }
 
@@ -40,8 +59,9 @@ func (t *QueueTracker) Register(q Queue) {
 }
 
 // Complete provides finalizing queue tracking. Deleting queue from itself and opening up one queue stack
-func (t *QueueTracker) Complete(q Queue) {
+func (t *QueueTracker) Complete(q Queue, ok bool) {
 	t.CurrentWorkings.Delete(q.ID)
+	t.ScoreBoard.ReportScore(ok)
 	<-t.queueStack // unblock
 }
 

--- a/queue_tracker.go
+++ b/queue_tracker.go
@@ -26,6 +26,10 @@ type ScoreBoard struct {
 	MaxWorker      int
 }
 
+func (s *ScoreBoard) TotalHandled() int64 {
+	return s.TotalSucceeded + s.TotalFailed
+}
+
 func (s *ScoreBoard) ReportScore(success bool) {
 	if success {
 		atomic.AddInt64(&s.TotalSucceeded, 1)

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -60,7 +60,7 @@ func TestQueueTracker(t *testing.T) {
 		t.Error("wrong order")
 	}
 
-	tracker.Complete(receivedQueue)
+	tracker.Complete(receivedQueue, true)
 
 	time.Sleep(10 * time.Microsecond)
 

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -60,7 +60,7 @@ func TestQueueTracker(t *testing.T) {
 		t.Error("wrong order")
 	}
 
-	tracker.Complete(receivedQueue, true)
+	tracker.Complete(receivedQueue)
 
 	time.Sleep(10 * time.Microsecond)
 

--- a/stat_handler.go
+++ b/stat_handler.go
@@ -147,6 +147,7 @@ func (h *StatHandler) ScoreBoardHandler() func(http.ResponseWriter, *http.Reques
 			TotalHandled:   int(h.Tracker.ScoreBoard.TotalSucceeded + h.Tracker.ScoreBoard.TotalFailed),
 			TotalSucceeded: int(h.Tracker.ScoreBoard.TotalSucceeded),
 			TotalFailed:    int(h.Tracker.ScoreBoard.TotalFailed),
+			MaxWorker:      h.Tracker.ScoreBoard.MaxWorker,
 			BusyWorker:     busy,
 			IdleWorker:     h.Tracker.ScoreBoard.MaxWorker - busy,
 		})

--- a/stat_handler.go
+++ b/stat_handler.go
@@ -144,7 +144,7 @@ func (h *StatHandler) ScoreBoardHandler() func(http.ResponseWriter, *http.Reques
 		busy := len(h.Tracker.queueStack)
 
 		renderJSON(w, &ScoreBoardResponse{
-			TotalHandled:   int(h.Tracker.ScoreBoard.TotalSucceeded + h.Tracker.ScoreBoard.TotalFailed),
+			TotalHandled:   int(h.Tracker.ScoreBoard.TotalHandled()),
 			TotalSucceeded: int(h.Tracker.ScoreBoard.TotalSucceeded),
 			TotalFailed:    int(h.Tracker.ScoreBoard.TotalFailed),
 			MaxWorker:      h.Tracker.ScoreBoard.MaxWorker,

--- a/stat_handler_test.go
+++ b/stat_handler_test.go
@@ -58,7 +58,7 @@ func TestRenderJSON(t *testing.T) {
 	}
 }
 
-func TestWorkerCurrentSummaryAndJobsHandler(t *testing.T) {
+func TestWorkerStatsAndJobsHandler(t *testing.T) {
 	tr := NewQueueTracker(5, NewLogger("DEBUG"))
 	h := &StatHandler{tr}
 
@@ -70,13 +70,13 @@ func TestWorkerCurrentSummaryAndJobsHandler(t *testing.T) {
 		})
 	}
 
-	summaryController := h.WorkerCurrentSummaryHandler()
+	workerStatsController := h.WorkerStatsHandler()
 	req := &http.Request{}
 	req.Method = "POST"
 
 	t.Run("invalid Method for summary", func(t *testing.T) {
 		w := NewMockResponseWriter()
-		summaryController(w, req)
+		workerStatsController(w, req)
 
 		if w.StatusCode != http.StatusMethodNotAllowed {
 			t.Error("response error found")
@@ -86,18 +86,18 @@ func TestWorkerCurrentSummaryAndJobsHandler(t *testing.T) {
 	t.Run("valid Method for summary", func(t *testing.T) {
 		w := NewMockResponseWriter()
 		req.Method = "GET"
-		summaryController(w, req)
+		workerStatsController(w, req)
 
 		if w.StatusCode != http.StatusOK {
 			t.Error("response error found")
 		}
 
-		var r StatCurrentSummaryResponse
+		var r StatWorkerStatsResponse
 		if err := json.Unmarshal(w.ResBytes, &r); err != nil {
 			t.Error("json unmarshal error", err)
 		}
 
-		if r.JobsCount != 5 {
+		if len(tr.CurrentSummaries()) != 5 {
 			t.Error("job summaries invalid")
 		}
 


### PR DESCRIPTION
I need a simple stats to know the success/failure of the Job that processed, so added it.

```
$ curl -s localhost:5950/scoreboard | jq
{
  "total_handled": 36,
  "total_succeeded": 36,
  "total_failed": 0,
  "max_worker": 10,
  "busy_worker": 0,
  "idle_worker": 10
}
```