### PR TITLE
fix sometime fail test

### DIFF
--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -2,7 +2,6 @@ package sqsd
 
 import (
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -15,8 +14,6 @@ func TestQueueTracker(t *testing.T) {
 	if tracker == nil {
 		t.Error("job tracker not loaded.")
 	}
-
-	mu := new(sync.Mutex)
 
 	now := time.Now()
 

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -62,7 +62,6 @@ func TestQueueTracker(t *testing.T) {
 	tracker.Complete(receivedQueue)
 
 	<-secondJobInsertNotify
-	time.Sleep(10 * time.Millisecond)
 
 	if !allJobRegistered {
 		t.Error("second job not registered")

--- a/queue_tracker_test.go
+++ b/queue_tracker_test.go
@@ -2,6 +2,7 @@ package sqsd
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ func TestQueueTracker(t *testing.T) {
 	if tracker == nil {
 		t.Error("job tracker not loaded.")
 	}
+
+	mu := new(sync.Mutex)
 
 	now := time.Now()
 
@@ -31,19 +34,13 @@ func TestQueueTracker(t *testing.T) {
 	}
 
 	allJobRegistered := false
-	firstJobInsertNotify := make(chan struct{})
-	secondJobInsertNotify := make(chan struct{})
-
 	go func() {
 		tracker.Register(q1)
-		firstJobInsertNotify <- struct{}{}
 		tracker.Register(q2)
 		allJobRegistered = true
-		secondJobInsertNotify <- struct{}{}
 	}()
 
-	<-firstJobInsertNotify
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	if allJobRegistered {
 		t.Error("2 jobs inserted")
@@ -61,7 +58,7 @@ func TestQueueTracker(t *testing.T) {
 
 	tracker.Complete(receivedQueue)
 
-	<-secondJobInsertNotify
+	time.Sleep(1 * time.Second)
 
 	if !allJobRegistered {
 		t.Error("second job not registered")


### PR DESCRIPTION
Sometimes, `tr.Registered` executing by another goroutine may not be in time for evaluation of allJobRegistered.

```
$ go test
2018/07/27 23:40:13 [INFO] MessageConsumer start.
2018/07/27 23:40:13 [DEBUG] job[TestHandleMessageNG] HandleJob start.
2018/07/27 23:40:13 [DEBUG] job[TestHandleMessageNG] HandleJob finished.
2018/07/27 23:40:13 [DEBUG] job[TestHandleMessageOK] HandleJob start.
2018/07/27 23:40:13 [DEBUG] job[TestHandleMessageOK] HandleJob finished.
2018/07/27 23:40:13 [DEBUG] job[TestHandleMessageErr] HandleJob start.
2018/07/27 23:40:13 [ERROR] job[TestHandleMessageErr] HandleJob request error: Post http://127.0.0.1:57889/long: context canceled
2018/07/27 23:40:13 [DEBUG] job[TestHandleMessageErr] HandleJob finished.
2018/07/27 23:40:13 [INFO] MessageConsumer closed.
2018/07/27 23:40:13 [DEBUG] tracker not working
2018/07/27 23:40:14 [ERROR] GetMessages Error: hogehoge
2018/07/27 23:40:15 [DEBUG] received no messages
2018/07/27 23:40:15 [DEBUG] received 1 messages. run jobs.

2018/07/27 23:40:15 [INFO] MessageProducer start. concurrency=1
2018/07/27 23:40:15 [INFO] context cancel detected. stop MessageProducer...
2018/07/27 23:40:16 [DEBUG] received no messages
2018/07/27 23:40:17 [INFO] MessageProducer closed.
--- FAIL: TestQueueTracker (0.01s)
	queue_tracker_test.go:69: second job not registered
2018/07/27 23:40:17 [WARN] healthcheck response code != 200: 500 Internal Server Error
2018/07/27 23:40:18 [WARN] healthcheck response code != 200: 500 Internal Server Error
2018/07/27 23:40:18 [WARN] healthcheck request failed. Get http://127.0.0.1:57908/long: context deadline exceeded
2018/07/27 23:40:19 [WARN] healthcheck request failed. Get http://127.0.0.1:57908/long: context deadline exceeded
2018/07/27 23:40:22 [WARN] healthcheck request failed. Get http://127.0.0.1:57908/long: context deadline exceeded
2018/07/27 23:40:22 [INFO] healthcheck request success.
FAIL
exit status 1
FAIL	github.com/taiyoh/sqsd	9.686s
```