### PR TITLE
build by static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ get-deps:
 
 build:
 	rm -rf pkg/v$(GIT_VERSION)/ && mkdir -p pkg/v$(GIT_VERSION)/dist
-	GOOS=linux   GOARCH=amd64 go build -o pkg/v$(GIT_VERSION)/sqsd_linux_amd64/sqsd       -ldflags=$(LDFLAGS) cmd/sqsd/main.go
+	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -o pkg/v$(GIT_VERSION)/sqsd_linux_amd64/sqsd       -ldflags=$(LDFLAGS) cmd/sqsd/main.go
 	cd pkg/v$(GIT_VERSION)/sqsd_linux_amd64   && tar cvzf sqsd_$(GIT_VERSION)_linux_amd64.tar.gz sqsd && mv sqsd_$(GIT_VERSION)_linux_amd64.tar.gz ../dist
-	GOOS=darwin  GOARCH=amd64 go build -o pkg/v$(GIT_VERSION)/sqsd_darwin_amd64/sqsd      -ldflags=$(LDFLAGS) cmd/sqsd/main.go
+	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -o pkg/v$(GIT_VERSION)/sqsd_darwin_amd64/sqsd      -ldflags=$(LDFLAGS) cmd/sqsd/main.go
 	cd pkg/v$(GIT_VERSION)/sqsd_darwin_amd64  && zip sqsd_$(GIT_VERSION)_darwin_amd64.zip * && mv sqsd_$(GIT_VERSION)_darwin_amd64.zip ../dist
-	GOOS=windows GOARCH=amd64 go build -o pkg/v$(GIT_VERSION)/sqsd_windows_amd64/sqsd.exe -ldflags=$(LDFLAGS) cmd/sqsd/main.go
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o pkg/v$(GIT_VERSION)/sqsd_windows_amd64/sqsd.exe -ldflags=$(LDFLAGS) cmd/sqsd/main.go
 	cd pkg/v$(GIT_VERSION)/sqsd_windows_amd64 && zip sqsd_$(GIT_VERSION)_windows_amd64.zip * && mv sqsd_$(GIT_VERSION)_windows_amd64.zip ../dist
 
 release:


### PR DESCRIPTION
Hi.

Current release is depends on glibc, so It is difficult to move with alpine or some base images.

```
root@5dd4fd4fee1e:~# ldd sqsd 
	linux-vdso.so.1 =>  (0x00007fff8b98c000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f74b21e8000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f74b1e1e000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f74b2405000)
```

Propose building with static link for better portability.

This has advantage that it does not depend on libc that base image supports when running on docker.