### PR TITLE
refactoring main function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/pelletier/go-toml v1.5.0
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/message_consumer.go
+++ b/message_consumer.go
@@ -88,7 +88,7 @@ func (c *MessageConsumer) HandleJob(ctx context.Context, q Queue) {
 		c.logger.Errorf("job[%s] HandleJob request error: %s", q.ID, err)
 		q = q.ResultFailed()
 	} else {
-		c.resource.DeleteMessage(q.Receipt)
+		c.resource.DeleteMessage(ctx, q.Receipt)
 		q = q.ResultSucceeded()
 	}
 	c.tracker.Complete(q)

--- a/message_consumer.go
+++ b/message_consumer.go
@@ -49,8 +49,7 @@ func NewMessageConsumer(resource *Resource, tracker *QueueTracker, invoker Worke
 }
 
 // Run provides receiving queue and execute HandleJob asyncronously.
-func (c *MessageConsumer) Run(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (c *MessageConsumer) Run(ctx context.Context) {
 	syncWait := &sync.WaitGroup{}
 	c.logger.Info("MessageConsumer start.")
 	for {

--- a/message_consumer_test.go
+++ b/message_consumer_test.go
@@ -36,8 +36,7 @@ func TestHandleJob(t *testing.T) {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		msgc.Run(ctx)
-		return nil
+		return msgc.Run(ctx)
 	})
 
 	t.Run("job failed", func(t *testing.T) {

--- a/message_consumer_test.go
+++ b/message_consumer_test.go
@@ -2,12 +2,12 @@ package sqsd_test
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/taiyoh/sqsd"
+	"golang.org/x/sync/errgroup"
 )
 
 type HandleJobResponse struct {
@@ -32,12 +32,13 @@ func TestHandleJob(t *testing.T) {
 	ts := MockServer()
 	defer ts.Close()
 
-	wg := &sync.WaitGroup{}
-
 	ctx, cancel := context.WithCancel(context.Background())
 
-	wg.Add(1)
-	go msgc.Run(ctx, wg)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		msgc.Run(ctx)
+		return nil
+	})
 
 	t.Run("job failed", func(t *testing.T) {
 		msgc.ChangeInvoker(sqsd.NewHTTPInvoker(ts.URL + "/error"))
@@ -110,5 +111,5 @@ func TestHandleJob(t *testing.T) {
 		t.Error("job remains")
 	}
 
-	wg.Wait()
+	eg.Wait()
 }

--- a/message_producer.go
+++ b/message_producer.go
@@ -2,8 +2,9 @@ package sqsd
 
 import (
 	"context"
-	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // MessageProducer provides receiving queues from SQS, and send to tracker
@@ -33,29 +34,30 @@ func NewMessageProducer(resource *Resource, tracker *QueueTracker, concurrency u
 }
 
 // Run executes DoHandle method asyncronously
-func (p *MessageProducer) Run(ctx context.Context) {
-	p.logger.Infof("MessageProducer start. concurrency=%d", p.concurrency)
-	syncWait := &sync.WaitGroup{}
-	syncWait.Add(p.concurrency)
-	for i := 0; i < p.concurrency; i++ {
-		go func() {
-			defer syncWait.Done()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					p.DoHandle(ctx)
-				}
+func (p *MessageProducer) Run(ctx context.Context) error {
+	c := p.concurrency
+	p.logger.Infof("MessageProducer start. concurrency=%d", c)
+	defer p.logger.Info("MessageProducer closed.")
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i := 0; i < c; i++ {
+		eg.Go(func() error {
+			for p.DoHandle(egCtx) {
+				// do handle
 			}
-		}()
+			return nil
+		})
 	}
-	go func() {
+	eg.Go(func() error {
 		<-ctx.Done()
 		p.logger.Info("context cancel detected. stop MessageProducer...")
-	}()
-	syncWait.Wait()
-	p.logger.Info("MessageProducer closed.")
+		return context.Canceled
+	})
+	err := eg.Wait()
+	if err == context.Canceled {
+		return nil
+	}
+	return err
 }
 
 // HandleEmpty executes HandleEmptyFunc parameter
@@ -64,25 +66,30 @@ func (p *MessageProducer) HandleEmpty() {
 }
 
 // DoHandle receiving queues from SQS, and sending queues to tracker
-func (p *MessageProducer) DoHandle(ctx context.Context) {
+func (p *MessageProducer) DoHandle(ctx context.Context) bool {
 	if !p.tracker.IsWorking() {
 		p.logger.Debug("tracker not working")
 		p.HandleEmpty()
-		return
+		return true
 	}
 	results, err := p.resource.GetMessages(ctx)
 	if err != nil {
+		if err == context.Canceled {
+			return false
+		}
 		p.logger.Errorf("GetMessages Error: %s", err)
 		p.HandleEmpty()
-		return
+		return true
 	}
 	if len(results) == 0 {
 		p.logger.Debug("received no messages")
 		p.HandleEmpty()
-		return
+		return true
 	}
 	p.logger.Debugf("received %d messages. run jobs.\n", len(results))
 	for _, msg := range results {
 		p.tracker.Register(NewQueue(msg))
 	}
+
+	return true
 }

--- a/message_producer.go
+++ b/message_producer.go
@@ -33,8 +33,7 @@ func NewMessageProducer(resource *Resource, tracker *QueueTracker, concurrency u
 }
 
 // Run executes DoHandle method asyncronously
-func (p *MessageProducer) Run(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (p *MessageProducer) Run(ctx context.Context) {
 	p.logger.Infof("MessageProducer start. concurrency=%d", p.concurrency)
 	syncWait := &sync.WaitGroup{}
 	syncWait.Add(p.concurrency)

--- a/message_producer_test.go
+++ b/message_producer_test.go
@@ -138,16 +138,17 @@ func TestReceiverRun(t *testing.T) {
 	sc := sqsd.SQSConf{URL: "http://example.com/foo/bar/queue", WaitTimeSec: 1}
 	rs := sqsd.NewResource(mc, sc)
 	tr := sqsd.NewQueueTracker(5, sqsd.NewLogger("DEBUG"))
-	pr := sqsd.NewMessageProducer(rs, tr, 1)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		pr.Run(ctx)
-		return nil
+	pr := sqsd.NewMessageProducer(rs, tr, 1, func() {
+		time.Sleep(100 * time.Millisecond)
 	})
 
-	time.Sleep(10 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return pr.Run(egCtx)
+	})
+
+	time.Sleep(50 * time.Millisecond)
 	cancel()
 	eg.Wait()
 }

--- a/mock_for_test.go
+++ b/mock_for_test.go
@@ -32,7 +32,6 @@ func NewMockClient() *MockClient {
 		Resp: &sqs.ReceiveMessageOutput{
 			Messages: []*sqs.Message{},
 		},
-		mu: sync.Mutex{},
 	}
 	c.RecvFunc = func(param *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
 		c.mu.Lock()
@@ -52,6 +51,9 @@ func NewMockClient() *MockClient {
 
 // ReceiveMessageWithContext is mock for same name method
 func (c *MockClient) ReceiveMessageWithContext(ctx aws.Context, param *sqs.ReceiveMessageInput, opts ...request.Option) (*sqs.ReceiveMessageOutput, error) {
+	if err := ctx.Err(); err != nil {
+		return c.Resp, err
+	}
 	o, e := c.RecvFunc(param)
 	return o, e
 }
@@ -59,8 +61,8 @@ func (c *MockClient) ReceiveMessageWithContext(ctx aws.Context, param *sqs.Recei
 // DeleteMessage is mock for same name method
 func (c *MockClient) DeleteMessage(*sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.DelRequestCount++
-	c.mu.Unlock()
 	return &sqs.DeleteMessageOutput{}, nil
 }
 

--- a/mock_for_test.go
+++ b/mock_for_test.go
@@ -59,11 +59,15 @@ func (c *MockClient) ReceiveMessageWithContext(ctx aws.Context, param *sqs.Recei
 }
 
 // DeleteMessage is mock for same name method
-func (c *MockClient) DeleteMessage(*sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
+func (c *MockClient) DeleteMessageWithContext(ctx aws.Context, input *sqs.DeleteMessageInput, opts ...request.Option) (*sqs.DeleteMessageOutput, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.DelRequestCount++
-	return &sqs.DeleteMessageOutput{}, nil
+	output := &sqs.DeleteMessageOutput{}
+	if err := ctx.Err(); err != nil {
+		return output, err
+	}
+	return output, nil
 }
 
 // MockServer provides test server with several response like error, long-time, and ok

--- a/mock_for_test.go
+++ b/mock_for_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/taiyoh/sqsd"
 )
 
 // MockClient provides mocking sqs library from aws-sdk-go for test
 type MockClient struct {
-	sqsiface.SQSAPI
 	Resp             *sqs.ReceiveMessageOutput
 	RecvRequestCount int
 	DelRequestCount  int
@@ -25,6 +24,8 @@ type MockClient struct {
 	mu               sync.Mutex
 	RecvFunc         func(*sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error)
 }
+
+var _ sqsd.SQSAPI = (*MockClient)(nil)
 
 // NewMockClient returns MockClient object
 func NewMockClient() *MockClient {

--- a/producer_consumer.go
+++ b/producer_consumer.go
@@ -1,0 +1,31 @@
+package sqsd
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"golang.org/x/sync/errgroup"
+)
+
+func RunProducerAndConsumer(
+	ctx context.Context,
+	api sqsiface.SQSAPI,
+	tracker *QueueTracker,
+	invoker WorkerInvoker,
+	conf SQSConf) error {
+	resource := NewResource(api, conf)
+	msgConsumer := NewMessageConsumer(resource, tracker, invoker)
+	msgProducer := NewMessageProducer(resource, tracker, conf.Concurrency)
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		msgConsumer.Run(ctx)
+		return nil
+	})
+	eg.Go(func() error {
+		msgProducer.Run(ctx)
+		return nil
+	})
+
+	return eg.Wait()
+}

--- a/producer_consumer.go
+++ b/producer_consumer.go
@@ -16,15 +16,13 @@ func RunProducerAndConsumer(
 	resource := NewResource(api, conf)
 	msgConsumer := NewMessageConsumer(resource, tracker, invoker)
 	msgProducer := NewMessageProducer(resource, tracker, conf.Concurrency)
-	eg, ctx := errgroup.WithContext(ctx)
 
+	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		msgConsumer.Run(ctx)
-		return nil
+		return msgConsumer.Run(ctx)
 	})
 	eg.Go(func() error {
-		msgProducer.Run(ctx)
-		return nil
+		return msgProducer.Run(ctx)
 	})
 
 	return eg.Wait()

--- a/resource.go
+++ b/resource.go
@@ -36,8 +36,8 @@ func (r *Resource) GetMessages(ctx context.Context) ([]*sqs.Message, error) {
 }
 
 // DeleteMessage provides queue deletion from SQS using aws sqs library
-func (r *Resource) DeleteMessage(receipt string) error {
-	_, err := r.client.DeleteMessage(&sqs.DeleteMessageInput{
+func (r *Resource) DeleteMessage(ctx context.Context, receipt string) error {
+	_, err := r.client.DeleteMessageWithContext(ctx, &sqs.DeleteMessageInput{
 		QueueUrl:      aws.String(r.url),
 		ReceiptHandle: aws.String(receipt),
 	})

--- a/resource.go
+++ b/resource.go
@@ -4,19 +4,26 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 )
+
+// SQSAPI provides partial interface for AWS SQS.
+type SQSAPI interface {
+	// sqsiface.SQSAPI
+	ReceiveMessageWithContext(aws.Context, *sqs.ReceiveMessageInput, ...request.Option) (*sqs.ReceiveMessageOutput, error)
+	DeleteMessageWithContext(aws.Context, *sqs.DeleteMessageInput, ...request.Option) (*sqs.DeleteMessageOutput, error)
+}
 
 // Resource is wrapper for aws sqs library
 type Resource struct {
-	client      sqsiface.SQSAPI
+	client      SQSAPI
 	url         string
 	waitTimeSec int64
 }
 
 // NewResource returns Resouce object
-func NewResource(client sqsiface.SQSAPI, c SQSConf) *Resource {
+func NewResource(client SQSAPI, c SQSConf) *Resource {
 	return &Resource{
 		client:      client,
 		url:         c.QueueURL(),

--- a/resource_test.go
+++ b/resource_test.go
@@ -30,7 +30,7 @@ func TestResource(t *testing.T) {
 		t.Error("what's wrong???")
 	}
 
-	if err := r.DeleteMessage(*c.Resp.Messages[0].ReceiptHandle); err != nil {
+	if err := r.DeleteMessage(ctx, *c.Resp.Messages[0].ReceiptHandle); err != nil {
 		t.Error("error founds")
 	}
 }


### PR DESCRIPTION
Some functions should be provided by sqsd.

- initializing SQS SDK object
- running StatHandler
- running Producer and Consumer

Also in handling goroutine, it's  nice to use with`errgroup.Group` than `sync.WaitGroup`.