### PR TITLE
create QueueLocker interface to block duplicate message from SQS

### DIFF
--- a/actor/go.mod
+++ b/actor/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.35.35
 	github.com/caarlos0/env/v6 v6.4.0
 	github.com/golang/protobuf v1.4.3
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/actor/go.sum
+++ b/actor/go.sum
@@ -162,8 +162,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=

--- a/actor/locker.go
+++ b/actor/locker.go
@@ -1,0 +1,103 @@
+package sqsd
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// QueueLocker represents locker interface for suppressing queue duplication.
+type QueueLocker interface {
+	Lock(context.Context, string) error
+	Find(context.Context, time.Time) ([]string, error)
+	Unlock(context.Context, ...string) error
+}
+
+// ErrQueueExists shows this queue is already registered.
+var ErrQueueExists = errors.New("queue exists")
+
+type memoryLocker struct {
+	pool sync.Map
+	dur  time.Duration
+}
+
+// MemoryLockerOption provides setting function to memory QueueLocker.
+type MemoryLockerOption func(*memoryLocker)
+
+var expireDur = 24 * time.Hour
+
+// MemoryLockerDuration sets expire duration to memory QueueLocker.
+func MemoryLockerDuration(dur time.Duration) MemoryLockerOption {
+	return func(ml *memoryLocker) {
+		ml.dur = dur
+	}
+}
+
+// NewMemoryQueueLocker creates QueueLocker to memory.
+func NewMemoryQueueLocker(opts ...MemoryLockerOption) QueueLocker {
+	ml := &memoryLocker{
+		dur: expireDur,
+	}
+	for _, opt := range opts {
+		opt(ml)
+	}
+	return ml
+}
+
+var _ QueueLocker = (*memoryLocker)(nil)
+
+// RunQueueLocker scan deletable ids and delete from QueueLocker periodically.
+func RunQueueLocker(ctx context.Context, l QueueLocker, interval time.Duration) {
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			ids, err := l.Find(ctx, time.Now().UTC())
+			if err != nil {
+				// TODO: logging
+				continue
+			}
+			if err := l.Unlock(ctx, ids...); err != nil {
+				// TODO: logging
+				continue
+			}
+		}
+	}
+}
+
+func (l *memoryLocker) Lock(_ context.Context, queueID string) error {
+	now := time.Now().UTC()
+	if val, ok := l.pool.Load(queueID); ok && val.(time.Time).After(now) {
+		return ErrQueueExists
+	}
+	expire := now.Add(l.dur)
+	l.pool.Store(queueID, expire)
+	return nil
+}
+
+func (l *memoryLocker) Find(_ context.Context, ts time.Time) ([]string, error) {
+	ids := make([]string, 0, 8)
+	l.pool.Range(func(key, value interface{}) bool {
+		if value.(time.Time).After(ts) {
+			ids = append(ids, key.(string))
+		}
+		return true
+	})
+	sort.Slice(ids, func(i, j int) bool {
+		return strings.Compare(ids[i], ids[j]) < 0
+	})
+	return ids, nil
+}
+
+func (l *memoryLocker) Unlock(_ context.Context, ids ...string) error {
+	for _, id := range ids {
+		l.pool.Delete(id)
+	}
+	return nil
+}

--- a/actor/locker.go
+++ b/actor/locker.go
@@ -101,3 +101,19 @@ func (l *memoryLocker) Unlock(_ context.Context, ids ...string) error {
 	}
 	return nil
 }
+
+type noopLocker struct{}
+
+var _ QueueLocker = (*noopLocker)(nil)
+
+func (noopLocker) Lock(_ context.Context, _ string) error {
+	return nil
+}
+
+func (noopLocker) Find(_ context.Context, _ time.Time) ([]string, error) {
+	return nil, nil
+}
+
+func (noopLocker) Unlock(_ context.Context, _ ...string) error {
+	return nil
+}

--- a/actor/locker_test.go
+++ b/actor/locker_test.go
@@ -1,0 +1,62 @@
+package sqsd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryLocker(t *testing.T) {
+	l := NewMemoryQueueLocker()
+	ctx := context.Background()
+
+	assert.NoError(t, l.Lock(ctx, "hogefuga"))
+	assert.NoError(t, l.Lock(ctx, "foobarbaz"))
+	assert.ErrorIs(t, l.Lock(ctx, "foobarbaz"), ErrQueueExists)
+
+	ids, err := l.Find(ctx, time.Now())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foobarbaz", "hogefuga"}, ids)
+
+	ids, err = l.Find(ctx, time.Now().Add(expireDur))
+	assert.NoError(t, err)
+	assert.Empty(t, ids)
+
+	assert.NoError(t, l.Unlock(ctx, "aiueo"))
+	ids, err = l.Find(ctx, time.Now())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foobarbaz", "hogefuga"}, ids)
+	assert.NoError(t, l.Unlock(ctx, "foobarbaz"))
+	ids, err = l.Find(ctx, time.Now())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"hogefuga"}, ids)
+	assert.NoError(t, l.Unlock(ctx, "hogefuga"))
+	ids, err = l.Find(ctx, time.Now())
+	assert.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+func TestRunQueueLocker(t *testing.T) {
+	l := NewMemoryQueueLocker(MemoryLockerDuration(50 * time.Millisecond))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go RunQueueLocker(ctx, l, 30*time.Millisecond)
+
+	assert.NoError(t, l.Lock(ctx, "hooooooooo"))
+	time.Sleep(25 * time.Millisecond)
+	assert.NoError(t, l.Lock(ctx, "baaaaaaaaa"))
+
+	for _, refs := range [][]string{
+		{
+			"baaaaaaaaa", "hooooooooo",
+		},
+		{},
+	} {
+		ids, _ := l.Find(ctx, time.Now().UTC())
+		assert.Equal(t, refs, ids)
+		time.Sleep(30 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
`QueueLocker` stops to send duplicated message to worker.
Sometimes SQS sends same message twice or over, so consumer (such as like `sqsd`) should determine this message is whether dupliceted or not.

Two approaches of avoiding duplicated message are considered:

1. worker (after `Invoker`) finds that message is duplicated
2. receiver (before `Invoker`) finds that message is duplicated

Current release version provides only 1 way of finding it from worker.
But to reduce complexity of worker, sqsd must also provides the way of finding it before worker runs.

`QueueLocker` interface has 3 methods:

1. `Lock`
  a. `Lock` receives sqs MessageId and keep it in specified periods.
2. `Find`
  a. `Find` returns expired MessageId list from supplied time.
3. `Unlock`
  a. `Unlock` removes supplied MessageId list from `QueueLocker`.

Default reference implementation of `QueueLocker` is in-memory locker (default expiration is 24 hours).
In my plan, redis locker and DynamoDB locker will be implemented to future release.

In this PR, `RunQueueLocker` is also implemented.
This function calls `Find` and `Unlock` of `QueueLocker` periodically with supplied interval, sqs MessageId which expired date has passed will be removed from `QueueLocker` storage automatically.