### PR TITLE
refactor(locker): change interface

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -104,7 +104,7 @@ func (g *Gateway) NewFetcherGroup(distributor *actor.PID, fns ...FetcherParamete
 		timeout:             g.timeout,
 		distributorInterval: time.Second,
 		fetcherInterval:     100 * time.Millisecond,
-		locker:              nooplocker.Instance,
+		locker:              nooplocker.Get(),
 	}
 	for _, fn := range fns {
 		fn(f)

--- a/locker/locker_test.go
+++ b/locker/locker_test.go
@@ -1,0 +1,55 @@
+package locker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taiyoh/sqsd/locker"
+	nooplocker "github.com/taiyoh/sqsd/locker/noop"
+)
+
+func TestUnlocker(t *testing.T) {
+	l, err := locker.NewUnlocker(nil, 0)
+	assert.Nil(t, l)
+	assert.EqualError(t, err, "locker is required")
+	nl := nooplocker.Get()
+
+	l, err = locker.NewUnlocker(nl, 0)
+	assert.Nil(t, l)
+	assert.EqualError(t, err, "interval must be greater than 0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := make(chan time.Time, 5)
+	nl.AddUnlockHook(func(c context.Context, t time.Time) error {
+		stream <- t
+		if len(stream) >= 3 {
+			cancel()
+		}
+		return nil
+	})
+
+	l, err = locker.NewUnlocker(nl, 50*time.Microsecond, locker.ExpireDuration(time.Hour))
+	assert.NoError(t, err)
+	assert.NotNil(t, l)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.Run(ctx)
+	}()
+	wg.Wait()
+	close(stream)
+	var counter int
+	now := time.Now().UTC()
+	for tt := range stream {
+		assert.True(t, tt.Before(now.Add(-time.Hour)))
+		counter++
+	}
+	assert.Equal(t, 3, counter)
+}

--- a/locker/memory/locker.go
+++ b/locker/memory/locker.go
@@ -13,25 +13,11 @@ type memoryLocker struct {
 	dur  time.Duration
 }
 
-// Option provides setting function to memory QueueLocker.
-type Option func(*memoryLocker)
-
-// Duration sets expire duration to memory QueueLocker.
-func Duration(dur time.Duration) Option {
-	return func(ml *memoryLocker) {
-		ml.dur = dur
+// New creates QueueLocker by memory.
+func New(dur time.Duration) locker.QueueLocker {
+	return &memoryLocker{
+		dur: dur,
 	}
-}
-
-// New creates QueueLocker to memory.
-func New(opts ...Option) locker.QueueLocker {
-	ml := &memoryLocker{
-		dur: locker.DefaultExpireDuration,
-	}
-	for _, opt := range opts {
-		opt(ml)
-	}
-	return ml
 }
 
 var _ locker.QueueLocker = (*memoryLocker)(nil)

--- a/locker/memory/locker_test.go
+++ b/locker/memory/locker_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMemoryLocker(t *testing.T) {
-	l := New()
+	l := New(24 * time.Hour)
 	ctx := context.Background()
 
 	assert.NoError(t, l.Lock(ctx, "hogefuga"))
@@ -54,32 +54,5 @@ func TestMemoryLocker(t *testing.T) {
 			})
 			assert.ElementsMatch(t, tt.want, keys)
 		})
-	}
-}
-
-func TestRunQueueLocker(t *testing.T) {
-	l := New(Duration(50 * time.Millisecond))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go locker.RunQueueLocker(ctx, l, 30*time.Millisecond)
-
-	assert.NoError(t, l.Lock(ctx, "hooooooooo"))
-	time.Sleep(25 * time.Millisecond)
-	assert.NoError(t, l.Lock(ctx, "baaaaaaaaa"))
-
-	for _, refs := range [][]string{
-		{
-			"baaaaaaaaa", "hooooooooo",
-		},
-		{},
-	} {
-		var keys []string
-		l.(*memoryLocker).pool.Range(func(key, value interface{}) bool {
-			keys = append(keys, key.(string))
-			return true
-		})
-		assert.ElementsMatch(t, refs, keys)
-		time.Sleep(30 * time.Millisecond)
 	}
 }

--- a/locker/memory/locker_test.go
+++ b/locker/memory/locker_test.go
@@ -14,29 +14,47 @@ func TestMemoryLocker(t *testing.T) {
 	ctx := context.Background()
 
 	assert.NoError(t, l.Lock(ctx, "hogefuga"))
-	assert.NoError(t, l.Lock(ctx, "foobarbaz"))
-	assert.ErrorIs(t, l.Lock(ctx, "foobarbaz"), locker.ErrQueueExists)
+	assert.ErrorIs(t, l.Lock(ctx, "hogefuga"), locker.ErrQueueExists)
 
-	ids, err := l.Find(ctx, time.Now())
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"foobarbaz", "hogefuga"}, ids)
+	t1 := time.Now().UTC()
 
-	ids, err = l.Find(ctx, time.Now().Add(locker.DefaultExpireDuration))
-	assert.NoError(t, err)
-	assert.Empty(t, ids)
+	{
+		ll := l.(*memoryLocker)
+		ll.pool.Store("hogefuga", t1.Add(-2*time.Second))
+		ll.pool.Store("foobarbaz", t1.Add(-1*time.Second))
+	}
 
-	assert.NoError(t, l.Unlock(ctx, "aiueo"))
-	ids, err = l.Find(ctx, time.Now())
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"foobarbaz", "hogefuga"}, ids)
-	assert.NoError(t, l.Unlock(ctx, "foobarbaz"))
-	ids, err = l.Find(ctx, time.Now())
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"hogefuga"}, ids)
-	assert.NoError(t, l.Unlock(ctx, "hogefuga"))
-	ids, err = l.Find(ctx, time.Now())
-	assert.NoError(t, err)
-	assert.Empty(t, ids)
+	for _, tt := range []struct {
+		label string
+		ts    time.Time
+		want  []string
+	}{
+		{
+			label: "case1",
+			ts:    t1.Add(-3 * time.Second),
+			want:  []string{"foobarbaz", "hogefuga"},
+		},
+		{
+			label: "case2",
+			ts:    t1.Add(-2*time.Second + 200*time.Millisecond),
+			want:  []string{"foobarbaz"},
+		},
+		{
+			label: "case3",
+			ts:    t1,
+			want:  []string{},
+		},
+	} {
+		t.Run(tt.label, func(t *testing.T) {
+			assert.NoError(t, l.Unlock(ctx, tt.ts))
+			var keys []string
+			l.(*memoryLocker).pool.Range(func(key, value interface{}) bool {
+				keys = append(keys, key.(string))
+				return true
+			})
+			assert.ElementsMatch(t, tt.want, keys)
+		})
+	}
 }
 
 func TestRunQueueLocker(t *testing.T) {
@@ -56,8 +74,12 @@ func TestRunQueueLocker(t *testing.T) {
 		},
 		{},
 	} {
-		ids, _ := l.Find(ctx, time.Now().UTC())
-		assert.Equal(t, refs, ids)
+		var keys []string
+		l.(*memoryLocker).pool.Range(func(key, value interface{}) bool {
+			keys = append(keys, key.(string))
+			return true
+		})
+		assert.ElementsMatch(t, refs, keys)
 		time.Sleep(30 * time.Millisecond)
 	}
 }

--- a/locker/noop/locker.go
+++ b/locker/noop/locker.go
@@ -16,10 +16,6 @@ func (noopLocker) Lock(_ context.Context, _ string) error {
 	return nil
 }
 
-func (noopLocker) Find(_ context.Context, _ time.Time) ([]string, error) {
-	return nil, nil
-}
-
-func (noopLocker) Unlock(_ context.Context, _ ...string) error {
+func (noopLocker) Unlock(_ context.Context, _ time.Time) error {
 	return nil
 }

--- a/locker/noop/locker.go
+++ b/locker/noop/locker.go
@@ -7,15 +7,41 @@ import (
 	"github.com/taiyoh/sqsd/locker"
 )
 
-type noopLocker struct{}
+type noopLocker struct {
+	lockHooks   []func(context.Context, string) error
+	unlockHooks []func(context.Context, time.Time) error
+}
 
-// Instance has noopLocker instance.
-var Instance locker.QueueLocker = &noopLocker{}
+// LockerWithHooks has noopLocker instance which has hooks interface.
+type LockerWithHooks interface {
+	locker.QueueLocker
+	AddLockHook(f func(context.Context, string) error)
+	AddUnlockHook(f func(context.Context, time.Time) error)
+}
 
-func (noopLocker) Lock(_ context.Context, _ string) error {
+// Get returns new noopLocker instance.
+func Get() LockerWithHooks {
+	return &noopLocker{}
+}
+
+func (l *noopLocker) Lock(ctx context.Context, key string) error {
+	for _, f := range l.lockHooks {
+		_ = f(ctx, key)
+	}
 	return nil
 }
 
-func (noopLocker) Unlock(_ context.Context, _ time.Time) error {
+func (l *noopLocker) Unlock(ctx context.Context, before time.Time) error {
+	for _, f := range l.unlockHooks {
+		_ = f(ctx, before)
+	}
 	return nil
+}
+
+func (l *noopLocker) AddLockHook(f func(context.Context, string) error) {
+	l.lockHooks = append(l.lockHooks, f)
+}
+
+func (l *noopLocker) AddUnlockHook(f func(context.Context, time.Time) error) {
+	l.unlockHooks = append(l.unlockHooks, f)
 }

--- a/locker/redis/locker.go
+++ b/locker/redis/locker.go
@@ -41,18 +41,6 @@ func (l *redislocker) Lock(ctx context.Context, queueID string) error {
 	}
 }
 
-func (l *redislocker) Find(ctx context.Context, ts time.Time) ([]string, error) {
-	// ascending order
-	return l.cli.ZRangeByScore(ctx, l.keyName, &redis.ZRangeBy{
-		Max: fmt.Sprintf("(%d", ts.UnixNano()),
-		Min: "-inf",
-	}).Result()
-}
-
-func (l *redislocker) Unlock(ctx context.Context, queueIDs ...string) error {
-	members := make([]interface{}, len(queueIDs))
-	for _, queueID := range queueIDs {
-		members = append(members, queueID)
-	}
-	return l.cli.ZRem(ctx, l.keyName, members...).Err()
+func (l *redislocker) Unlock(ctx context.Context, ts time.Time) error {
+	return l.cli.ZRemRangeByScore(ctx, l.keyName, "-inf", fmt.Sprintf("%d", ts.UnixNano())).Err()
 }


### PR DESCRIPTION
 - simplify `locker.QueueLocker` interface
 - re-design unlocking process by struct