### PR TITLE
brush-up codes for 1.23 over

### DIFF
--- a/aws_setup_test.go
+++ b/aws_setup_test.go
@@ -21,7 +21,8 @@ const awsRegion = "ap-northeast-1"
 
 func init() {
 	if _, ok := os.LookupEnv("SQS_ENDPOINT_URL"); !ok {
-		os.Setenv("SQS_ENDPOINT_URL", "http://localhost:9324")
+		//nolint:errcheck // ignore for test
+		_ = os.Setenv("SQS_ENDPOINT_URL", "http://localhost:9324")
 	}
 
 	var err error

--- a/consumer.go
+++ b/consumer.go
@@ -33,7 +33,7 @@ func startWorker(ctx context.Context, ivk Invoker, broker chan Message, rm remov
 		invoker:   ivk,
 		semaphore: semaphore.NewWeighted(int64(capacity)),
 	}
-	for i := 0; i < capacity; i++ {
+	for range capacity {
 		go w.RunForProcess(ctx, broker, rm)
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -42,7 +42,7 @@ func startWorker(ctx context.Context, ivk Invoker, broker chan Message, rm remov
 
 type taskList []*Task
 
-func (tasks *taskList) Range(key, val interface{}) bool {
+func (tasks *taskList) Range(key, val any) bool {
 	*tasks = append(*tasks, val.(*Task))
 	return true
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -53,7 +53,7 @@ func TestWorker(t *testing.T) {
 		sort.Slice(tasks, func(i, j int) bool {
 			return strings.Compare(tasks[i].Id, tasks[j].Id) < 0
 		})
-		for i := 0; i < len(chunk); i++ {
+		for i := range len(chunk) {
 			id := fmt.Sprintf("id:%d", (i+1)+(p*3))
 			assert.Equal(t, id, tasks[i].Id)
 			nextCh <- struct{}{}

--- a/gateway.go
+++ b/gateway.go
@@ -122,7 +122,7 @@ func FetchParallel(n int) GatewayParameter {
 func (f Gateway) start(ctx context.Context, broker chan Message) {
 	var wg sync.WaitGroup
 	wg.Add(f.parallel)
-	for i := 0; i < f.parallel; i++ {
+	for range f.parallel {
 		go f.runForFetch(ctx, &wg, broker, f.input)
 	}
 	wg.Wait()
@@ -174,7 +174,7 @@ func (g *Gateway) remove(ctx context.Context, msg Message) (err error) {
 		return nil
 	}
 	logger := getLogger()
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		_, err = g.queue.DeleteMessage(ctx, &sqs.DeleteMessageInput{
 			QueueUrl:      &g.queueURL,

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -22,7 +22,7 @@ func TestFetcherAndRemover(t *testing.T) {
 		panic(err)
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		body := fmt.Sprintf(`{"foo":"bar","hoge":100,"index":%d}`, i)
 		_, err := queue.SendMessage(context.Background(), &sqs.SendMessageInput{
 			QueueUrl:    &queueURL,

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -19,7 +19,7 @@ func TestGRPC(t *testing.T) {
 	assert.NotNil(t, l)
 	port, err := strconv.Atoi(strings.Split(l.Addr().String(), ":")[1])
 	assert.NoError(t, err)
-	l.Close()
+	assert.NoError(t, l.Close())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -34,10 +34,9 @@ func TestGRPC(t *testing.T) {
 	grpcServer.Start()
 	defer grpcServer.Stop()
 
-	conn, err := grpc.Dial(
+	conn, err := grpc.NewClient(
 		fmt.Sprintf("localhost:%d", port),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 
 	assert.NoError(t, err)

--- a/invoker.go
+++ b/invoker.go
@@ -46,6 +46,7 @@ func (ivk *HTTPInvoker) Invoke(ctx context.Context, q Message) error {
 	if err != nil {
 		return err
 	}
+	//nolint:errcheck // ignore error for defer
 	defer resp.Body.Close()
 	logger := getLogger()
 	switch s := resp.StatusCode; {

--- a/locker/memory/locker.go
+++ b/locker/memory/locker.go
@@ -29,8 +29,8 @@ func (l *memoryLocker) Lock(_ context.Context, queueID string) error {
 }
 
 func (l *memoryLocker) Unlock(_ context.Context, ts time.Time) error {
-	var keys []interface{}
-	l.pool.Range(func(key, value interface{}) bool {
+	var keys []any
+	l.pool.Range(func(key, value any) bool {
 		if value.(time.Time).Before(ts) {
 			keys = append(keys, key)
 		}

--- a/locker/memory/locker_test.go
+++ b/locker/memory/locker_test.go
@@ -48,7 +48,7 @@ func TestMemoryLocker(t *testing.T) {
 		t.Run(tt.label, func(t *testing.T) {
 			assert.NoError(t, l.Unlock(ctx, tt.ts))
 			var keys []string
-			l.(*memoryLocker).pool.Range(func(key, value interface{}) bool {
+			l.(*memoryLocker).pool.Range(func(key, value any) bool {
 				keys = append(keys, key.(string))
 				return true
 			})

--- a/monitoring_service_test.go
+++ b/monitoring_service_test.go
@@ -47,7 +47,7 @@ func TestMonitoringService(t *testing.T) {
 	tasks := resp.GetTasks()
 	assert.Len(t, tasks, 3)
 	ids := make([]string, 0, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		ids = append(ids, tasks[i].GetId())
 		nextCh <- struct{}{}
 	}
@@ -71,7 +71,7 @@ func TestMonitoringService(t *testing.T) {
 	tasks = resp.GetTasks()
 	assert.Len(t, tasks, 3)
 	ids2 := make([]string, 0, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		ids2 = append(ids2, tasks[i].GetId())
 		nextCh <- struct{}{}
 	}
@@ -94,7 +94,7 @@ func TestMonitoringService(t *testing.T) {
 	tasks = resp.GetTasks()
 	assert.Len(t, tasks, 3)
 	ids3 := make([]string, 0, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		ids3 = append(ids3, tasks[i].GetId())
 		nextCh <- struct{}{}
 	}

--- a/system_test.go
+++ b/system_test.go
@@ -26,7 +26,7 @@ func TestSystem(t *testing.T) {
 	assert.NotNil(t, l)
 	port, err := strconv.Atoi(strings.Split(l.Addr().String(), ":")[1])
 	assert.NoError(t, err)
-	l.Close()
+	assert.NoError(t, l.Close())
 	sys := NewSystem(
 		GatewayBuilder(queue, queueURL, 1, time.Hour),
 		ConsumerBuilder(nil, 3),


### PR DESCRIPTION
This pull request introduces several changes aimed at improving code readability, consistency, and robustness across multiple files. The key updates include replacing `interface{}` with the more modern `any` type, enhancing error handling in test cases, and simplifying loop constructs for better clarity.

### Type Consistency Improvements:
* Replaced `interface{}` with `any` in method signatures and range functions to align with modern Go practices (`consumer.go`, `locker/memory/locker.go`, `locker/memory/locker_test.go`). [[1]](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82L45-R45) [[2]](diffhunk://#diff-c85c087b45a4f3470a14e85e0a5d61f5a5e3518911a96ef3083c02a797fa8008L32-R33) [[3]](diffhunk://#diff-2b529512658d5c2378edb3959d88a69b9c22b93b305cac9618eafbc20fd2c952L51-R51)

### Loop Simplifications:
* Simplified `for` loops by replacing `for i := 0; i < n; i++` with `for i := range n` for better readability and to reduce potential off-by-one errors. Changes applied across multiple test and implementation files (`consumer.go`, `consumer_test.go`, `gateway.go`, `gateway_test.go`, `monitoring_service_test.go`). [[1]](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82L36-R36) [[2]](diffhunk://#diff-f34d00b6d77e43602f0545b75f4516d79984a661f71075d7b44f694123adce9cL56-R56) [[3]](diffhunk://#diff-381fc1538fcabc4f3c951608256b04bfb57661fd8940f39eeb49e30a1345b938L125-R125) [[4]](diffhunk://#diff-381fc1538fcabc4f3c951608256b04bfb57661fd8940f39eeb49e30a1345b938L177-R177) [[5]](diffhunk://#diff-865a261d2982ae32546623faa4bea646e09207adcf5e0be393088d76d5feac5eL25-R25) [[6]](diffhunk://#diff-e6e754e592cedaf005513cdbcfe59849c99f47a861db185539ea8a229bd5207bL50-R50) [[7]](diffhunk://#diff-e6e754e592cedaf005513cdbcfe59849c99f47a861db185539ea8a229bd5207bL74-R74) [[8]](diffhunk://#diff-e6e754e592cedaf005513cdbcfe59849c99f47a861db185539ea8a229bd5207bL97-R97)

### Enhanced Error Handling:
* Added error handling in test cases to ensure that resources are properly closed and errors are asserted, improving test robustness (`grpc_test.go`, `system_test.go`). [[1]](diffhunk://#diff-8607aa31e03be6592454f8d20f63839b834d4566ba7f3a9afea46e4e320065f6L22-R22) [[2]](diffhunk://#diff-d9b35fba06a6a9d3113186d12f5e7c29ac94cf1d10b6f202f4f1addd3537ecb3L29-R29)

### Minor Code Quality Improvements:
* Suppressed linter warnings for specific cases where errors are intentionally ignored, with comments explaining the rationale (`aws_setup_test.go`, `invoker.go`). [[1]](diffhunk://#diff-33ffc6785481eaaaf4dbb960b3fdb15beaf024795dbf411b0ff81c5f44f52415L24-R25) [[2]](diffhunk://#diff-64f7828f1129f7091326ab7f73d52b42d1f2197c614016f66bcd8573ecdb40feR49)

### Refactoring of GRPC Client Initialization:
* Replaced `grpc.Dial` with `grpc.NewClient` for better abstraction and clarity in test setup (`grpc_test.go`).