### PR TITLE
fix(sqsd): inject waitgroup to ctx to wait process ends

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -33,6 +33,9 @@ func startWorker(ctx context.Context, ivk Invoker, broker chan Message, rm remov
 		invoker:   ivk,
 		semaphore: semaphore.NewWeighted(int64(capacity)),
 	}
+	if wg := wgFrom(ctx); wg != nil {
+		wg.Add(capacity)
+	}
 	for range capacity {
 		go w.RunForProcess(ctx, broker, rm)
 	}
@@ -100,7 +103,6 @@ func (w *worker) wrappedProcess(msg Message, rm remover) {
 
 func (w *worker) RunForProcess(ctx context.Context, broker chan Message, rm remover) {
 	if wg := wgFrom(ctx); wg != nil {
-		wg.Add(1)
 		defer wg.Done()
 	}
 	for {

--- a/consumer.go
+++ b/consumer.go
@@ -99,6 +99,10 @@ func (w *worker) wrappedProcess(msg Message, rm remover) {
 }
 
 func (w *worker) RunForProcess(ctx context.Context, broker chan Message, rm remover) {
+	if wg := wgFrom(ctx); wg != nil {
+		wg.Add(1)
+		defer wg.Done()
+	}
 	for {
 		select {
 		case <-ctx.Done():

--- a/gateway.go
+++ b/gateway.go
@@ -120,18 +120,25 @@ func FetchParallel(n int) GatewayParameter {
 }
 
 func (f Gateway) start(ctx context.Context, broker chan Message) {
+	if mainWg := wgFrom(ctx); mainWg != nil {
+		mainWg.Add(1)
+		defer mainWg.Done()
+	}
 	var wg sync.WaitGroup
 	wg.Add(f.parallel)
+	fetchCtx := wgTo(ctx, &wg)
 	for range f.parallel {
-		go f.runForFetch(ctx, &wg, broker, f.input)
+		go f.runForFetch(fetchCtx, broker, f.input)
 	}
 	wg.Wait()
 
 	close(broker)
 }
 
-func (f *Gateway) runForFetch(ctx context.Context, wg *sync.WaitGroup, broker chan Message, input *sqs.ReceiveMessageInput) {
-	defer wg.Done()
+func (f *Gateway) runForFetch(ctx context.Context, broker chan Message, input *sqs.ReceiveMessageInput) {
+	if wg := wgFrom(ctx); wg != nil {
+		defer wg.Done()
+	}
 	logger := getLogger()
 	for {
 		if err := ctx.Err(); err != nil {

--- a/system.go
+++ b/system.go
@@ -74,8 +74,8 @@ func (s *System) Run(ctx context.Context) error {
 	msgsCh := make(chan Message, s.capacity)
 
 	var wg sync.WaitGroup
-	wg.Add(s.capacity)
-	worker := startWorker(wgTo(ctx, &wg), s.invoker, msgsCh, s.gateway)
+	ctx = wgTo(ctx, &wg)
+	worker := startWorker(ctx, s.invoker, msgsCh, s.gateway)
 
 	monitor := NewMonitoringService(worker)
 
@@ -89,11 +89,7 @@ func (s *System) Run(ctx context.Context) error {
 		defer grpcServer.Stop()
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		s.gateway.start(ctx, msgsCh)
-	}()
+	go s.gateway.start(ctx, msgsCh)
 
 	<-ctx.Done()
 	getLogger().Info("signal caught. stopping worker...")

--- a/system.go
+++ b/system.go
@@ -55,10 +55,27 @@ func NewSystem(builders ...SystemBuilder) *System {
 	return sys
 }
 
+type wgKey struct{}
+
+func wgFrom(ctx context.Context) *sync.WaitGroup {
+	wg, ok := ctx.Value(wgKey{}).(*sync.WaitGroup)
+	if !ok {
+		return nil
+	}
+	return wg
+}
+
+func wgTo(ctx context.Context, wg *sync.WaitGroup) context.Context {
+	return context.WithValue(ctx, wgKey{}, wg)
+}
+
 // Run starts running actors and gRPC server.
 func (s *System) Run(ctx context.Context) error {
 	msgsCh := make(chan Message, s.capacity)
-	worker := startWorker(ctx, s.invoker, msgsCh, s.gateway)
+
+	var wg sync.WaitGroup
+	wg.Add(s.capacity)
+	worker := startWorker(wgTo(ctx, &wg), s.invoker, msgsCh, s.gateway)
 
 	monitor := NewMonitoringService(worker)
 
@@ -72,7 +89,6 @@ func (s *System) Run(ctx context.Context) error {
 		defer grpcServer.Stop()
 	}
 
-	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
This pull request introduces changes to improve concurrency management by integrating `sync.WaitGroup` into the context for better synchronization of goroutines. The changes primarily focus on ensuring proper cleanup and coordination of worker and gateway processes.

### Concurrency Management Enhancements:

* **Added `wgFrom` and `wgTo` utility functions**: These functions allow embedding and retrieving a `sync.WaitGroup` from a `context.Context`, enabling seamless synchronization across goroutines. (`system.go`: [system.goR58-R77](diffhunk://#diff-a3d50515e35f5f105ef9cfc114669a8d74a97f951fc3f92c4bb68fc5b0782fceR58-R77))
* **Integrated `WaitGroup` into `System.Run`**: The `System.Run` method now embeds a `WaitGroup` into the context, replacing the manual `WaitGroup` management, ensuring all goroutines spawned by the system are properly synchronized. (`system.go`: [system.goL75-R92](diffhunk://#diff-a3d50515e35f5f105ef9cfc114669a8d74a97f951fc3f92c4bb68fc5b0782fceL75-R92))

### Worker Process Improvements:

* **Worker synchronization using `WaitGroup`**: The `startWorker` and `RunForProcess` methods now utilize the `WaitGroup` from the context to ensure proper cleanup of worker goroutines when the context is canceled. (`consumer.go`: [[1]](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R36-R38) [[2]](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R105-R107)

### Gateway Process Improvements:

* **Enhanced gateway synchronization**: The `start` and `runForFetch` methods in `Gateway` now use the `WaitGroup` from the context for better coordination of fetch operations, ensuring all goroutines complete before proceeding. (`gateway.go`: [gateway.goR123-R141](diffhunk://#diff-381fc1538fcabc4f3c951608256b04bfb57661fd8940f39eeb49e30a1345b938R123-R141))