### PR TITLE
fix: waiting worker ends before process ends

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -25,6 +25,7 @@ type worker struct {
 	workings  sync.Map
 	invoker   Invoker
 	semaphore *semaphore.Weighted
+	wg        sync.WaitGroup
 }
 
 func startWorker(ctx context.Context, ivk Invoker, broker chan Message, rm remover) *worker {
@@ -33,11 +34,17 @@ func startWorker(ctx context.Context, ivk Invoker, broker chan Message, rm remov
 		invoker:   ivk,
 		semaphore: semaphore.NewWeighted(int64(capacity)),
 	}
+	w.wg.Add(capacity)
 	for range capacity {
 		go w.RunForProcess(ctx, broker, rm)
 	}
 
 	return w
+}
+
+// Wait waits until all workers are stopped.
+func (w *worker) Wait() {
+	w.wg.Wait()
 }
 
 type taskList []*Task
@@ -99,6 +106,7 @@ func (w *worker) wrappedProcess(msg Message, rm remover) {
 }
 
 func (w *worker) RunForProcess(ctx context.Context, broker chan Message, rm remover) {
+	defer w.wg.Done()
 	for {
 		select {
 		case <-ctx.Done():

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -19,7 +19,6 @@ func (f testInvoker) Invoke(ctx context.Context, q Message) error {
 
 func TestWorker(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	rcvCh := make(chan Message, 100)
 	nextCh := make(chan struct{}, 100)
 	testInvokerFn := func(ctx context.Context, q Message) error {
@@ -60,4 +59,7 @@ func TestWorker(t *testing.T) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+
+	cancel()
+	w.Wait()
 }

--- a/system.go
+++ b/system.go
@@ -86,6 +86,7 @@ func (s *System) Run(ctx context.Context) error {
 		return err
 	}
 
+	worker.Wait()
 	wg.Wait()
 
 	return nil


### PR DESCRIPTION
This pull request enhances the worker lifecycle management in the `consumer` package by introducing a `sync.WaitGroup` to ensure all worker goroutines complete before the program exits. Key changes include adding the `WaitGroup` to the `worker` struct, updating the worker initialization and shutdown process, and adjusting the tests to align with the new behavior.

### Worker lifecycle improvements:

* `consumer.go`:
  - Added a `sync.WaitGroup` (`wg`) to the `worker` struct to track the lifecycle of worker goroutines.
  - Updated the `startWorker` function to initialize the `WaitGroup` with the number of workers and ensure proper tracking.
  - Added a `Wait` method to the `worker` struct to block until all worker goroutines have completed.
  - Ensured each worker decrements the `WaitGroup` counter when exiting by adding `defer w.wg.Done()` in `RunForProcess`.

### Test updates:

* `consumer_test.go`:
  - Removed premature test cleanup (`t.Cleanup(cancel`) and explicitly called `cancel()` and `w.Wait()` at the end of the test to ensure proper worker shutdown. [[1]](diffhunk://#diff-f34d00b6d77e43602f0545b75f4516d79984a661f71075d7b44f694123adce9cL22) [[2]](diffhunk://#diff-f34d00b6d77e43602f0545b75f4516d79984a661f71075d7b44f694123adce9cR62-R64)

### System-level integration:

* `system.go`:
  - Added a call to `worker.Wait()` in the `Run` method of the `System` struct to ensure all workers finish before proceeding.This pull request introduces changes to improve the lifecycle management of worker goroutines in the `consumer.go` and `system.go` files. The most significant updates include adding a `sync.WaitGroup` to the `worker` struct for better synchronization and ensuring all workers are properly stopped before exiting.

### Worker lifecycle management improvements:

* [`consumer.go`](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R28): Added a `sync.WaitGroup` (`wg`) to the `worker` struct to track active worker goroutines.
* [`consumer.go`](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R37-R49): Updated the `startWorker` function to initialize the `WaitGroup` with the number of workers and added a `Wait` method to the `worker` struct to wait for all workers to complete.
* [`consumer.go`](diffhunk://#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R109): Modified the `RunForProcess` method to call `wg.Done()` when a worker finishes, ensuring proper decrementing of the `WaitGroup`.

### System-wide synchronization:

* [`system.go`](diffhunk://#diff-a3d50515e35f5f105ef9cfc114669a8d74a97f951fc3f92c4bb68fc5b0782fceR89): Updated the `Run` method to call `worker.Wait()` before waiting on the main `WaitGroup`, ensuring all workers are stopped before the system shuts down.